### PR TITLE
update readme and fix error 'cannot load such file -- kramdown-parser-gfm'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source "https://rubygems.org"
 gemspec
+gem "kramdown-parser-gfm"

--- a/README.md
+++ b/README.md
@@ -35,9 +35,10 @@ This theme comes in nine different skins (in addition to the default one).
 
 ## Installation
 
-- Download this repository
-- Install the requried gems: `bundle install`
-- Run the jekyll server: `bundle exec jekyll serve`
+- Install [Ruby and Jekyll](https://jekyllrb.com/docs/installation/ubuntu/)
+- `clone` this repository
+- Install the required gems: `bundle install`
+- Run the jekyll server with automatic reload and binding to all interfaces: `bundle exec jekyll serve --incremental --host=0.0.0.0`
 
 You should have a server up and running locally on the usual dev/test port of 4000
 


### PR DESCRIPTION
This PR:

* updates readme on how to install and run Jekyll
* fixes error when I try and serve the site I get an error (see below) and this PR fixes the missing gem to the `Gemfile`: 

```
bash-4.3# bundle exec jekyll serve
Configuration file: /srv/jekyll/_config.yml
            Source: /srv/jekyll
       Destination: /srv/jekyll/_site
 Incremental build: disabled. Enable with --incremental                                          
      Generating...           
        Pagination: Pagination is enabled, but I couldn't find an index.html page to use as the pagination template. Skipping pagination.                                                          
       Jekyll Feed: Generating feed for posts
  Dependency Error: Yikes! It looks like you don't have kramdown-parser-gfm or one of its dependencies installed. In order to use Jekyll as currently configured, you'll need to install this gem. 
The full error message from Ruby is: 'cannot load such file -- kramdown-parser-gfm' If you run into trouble, you can find helpful resources at https://jekyllrb.com/help/!                         
  Conversion error: Jekyll::Converters::Markdown encountered an error while converting '_equipment/3d_printers.md':                                                                                
                    kramdown-parser-gfm
             ERROR: YOUR SITE COULD NOT BE BUILT:                                                
                    ------------------------------------                                         
                    kramdown-parser-gfm
```