### PR TITLE
lock ruby v between local dev and CloudFlare

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Changes to `main` will deploy automatically to Cloudflare and update the website
 
 CF does not use the default Jekyll settings, instead it uses a custom build command with `jekyll build && cp _redirects _site/_redirects`, which allows for the redirects to work as expected. (Default selection of Jekyll from the drop down will only result in `jekyll build`)
 
+In the project settings for the Pages entry for this in Cloudflare, it is important to make sure the `RUBY_VERSION` environment variable is always set to the same version as the one inside `minimal-mistakes-jekyll.gemspec`. It would be best to leave this version as currently set, unless an update is needed for dependency or security issues.
+
 ## License
 
 The MIT License (MIT)

--- a/minimal-mistakes-jekyll.gemspec
+++ b/minimal-mistakes-jekyll.gemspec
@@ -15,6 +15,9 @@ Gem::Specification.new do |spec|
     f.match(%r{^(assets|_(data|includes|layouts|sass)/|(LICENSE|README|CHANGELOG)((\.(txt|md|markdown)|$)))}i)
   end
 
+  #locks ruby version to ensure local dev and CloudFlare are in sync. Only change this if you have a good reason!
+  spec.required_ruby_version = "~> 3.2.2"
+
   spec.add_runtime_dependency "jekyll", ">= 3.7", "< 5.0"
   spec.add_runtime_dependency "jekyll-paginate", "~> 1.1"
   spec.add_runtime_dependency "jekyll-sitemap", "~> 1.3"


### PR DESCRIPTION
This PR added a locked ruby version to the gemspec, to make sure Dev work done locally is always on the same version as the cloudflare pages server. It's okay for someone to update this version if needed, but by doing it this way it will help ensure they are updated on both ends in lockstep to avoid dependency confusion in the future.