### PR TITLE
Update super-linter.yml

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: github/super-linter@v4
+        uses: github/super-linter@v5
         env:
           VALIDATE_JSCPD: false
           VALIDATE_NATURAL_LANGUAGE: false


### PR DESCRIPTION
migrating superlinter to v5, as v4 uses deprecated GH node support.