### PR TITLE
Copy cleanup pass

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: github/super-linter@v6.0.0
+        uses: github/super-linter@v4
         env:
           VALIDATE_JSCPD: false
           VALIDATE_NATURAL_LANGUAGE: false

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: github/super-linter@v4
+        uses: github/super-linter@v5
         env:
           VALIDATE_JSCPD: false
           VALIDATE_NATURAL_LANGUAGE: false

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: github/super-linter@v6
+        uses: github/super-linter@v6.0.0
         env:
           VALIDATE_JSCPD: false
           VALIDATE_NATURAL_LANGUAGE: false

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: github/super-linter@v4
+        uses: github/super-linter@v6.0.0
         env:
           VALIDATE_JSCPD: false
           VALIDATE_NATURAL_LANGUAGE: false

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: github/super-linter@v6.0.0
+        uses: github/super-linter@v6
         env:
           VALIDATE_JSCPD: false
           VALIDATE_NATURAL_LANGUAGE: false

--- a/_equipment/craft_room.md
+++ b/_equipment/craft_room.md
@@ -27,3 +27,5 @@ In our crafting room we have a variety of tools (and our network server rack!)
 - [Silhouette Cameo cutting machine](https://rtfm.synshop.org/users/Equipment/Silhoutte%20Cameo/)
 - Thermal Laminator
 - Leatherworking Hand tools
+- Hot Glue equipment and supplies
+- Misc. notions, fabrics, and other crafting supplies

--- a/_equipment/danger_room.md
+++ b/_equipment/danger_room.md
@@ -22,7 +22,7 @@ order: 3
 THE DANGER ROOM!
 Everything in this room requires that you have a [waiver on file](/membership#liability-wavier) and have been certified for a particular tool by a trained member!
 
-*(Several pieces of hardware are temporarily offline while we get our three-phase power wired up in our new facility. Please check folks on Discord or at the Shop to see what is current available for use.)*
+*(Several pieces of hardware are temporarily offline while we get our three-phase power wired up in our new facility. Please check with folks on Discord or locally at the Shop to see what is current available for use.)*
 
 ## Large Equipment
 

--- a/_equipment/electronics_shop.md
+++ b/_equipment/electronics_shop.md
@@ -36,3 +36,5 @@ A non-exhaustive list of the various things available in the electronics room
 - Digital Multi Meter
 - SMD Hotair rework station
 - Miscellaneous circuitry parts
+- Various cables of countles varities
+- Misc. power adapters

--- a/_equipment/print_shop.md
+++ b/_equipment/print_shop.md
@@ -19,7 +19,7 @@ order: 7
 
 ## Print Shop
 
-We have a print shop room with printing & binding supplies
+We have a "2D" Print Shop room with printing & binding supplies
 
 ## Equipment
 
@@ -28,4 +28,4 @@ A non-exhaustive list of the various things available in the Print Shop room
 - [Sharp MX3070V](/equipment/sharp_printer/)
 - [Canon iPF6400SE 24" Large Format Printer](/equipment/canon_lf_printer/)
 - [40" Rotary Cutter](/equipment/rotary_cutter)
-- Misc book-binding equipment.
+- Misc book-binding equipment for comb and spiral binding

--- a/_equipment/rotary_cutter.md
+++ b/_equipment/rotary_cutter.md
@@ -19,4 +19,4 @@ order: 70
 
 ## Rotary Cutter
 
-40" rotary cutter with LED lighting
+40" rotary cutter frame with LED lighting

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -37,7 +37,7 @@ header:
 
 ## Overview
 
-SYN Shop is a hackerspace serving the Las Vegas Valley in Nevada. It is a space for sharing, creation, collaboration, research, development, mentoring, and of course, learning. Our motto is: "Let's make stuff awesome!"
+SYN Shop is a hackerspace serving the Las Vegas Valley in Nevada. It is a space for sharing, creation, collaboration, research, development, mentoring, and of course, learning. Our motto is: *"Let's make stuff awesome!"*
 
 #### History
 
@@ -47,19 +47,19 @@ SYN Shop was started back in 2008, when a bunch of DIY enthusiasts decided that 
 
 We are hackers, makers, artists, innovators, inventors, people of knowledge, and people who want to learn. We are people who take things apart to see how they work. We design the new because it has not been done before, and we reinvent what has already been done for the challenge of doing it ourselves. We're here to discover the unknown. To teach others, and to put our mark on the world by helping others. We're here to form a community of people who come together to share resources and knowledge to build and make things.
 
-#### What We Are Not
+#### What We Are ***Not***
 
-We may be hackers, but we are hackers in the same sense that Steve Wozniak or Dean Kamen are hackers. We're not here to break into your ex's cell phone/computer/automobile, etc.. We're not the people who attack and deface web sites, steal people's credit card information, or even identities. In fact many of us work in industries which protect against such people.
+We may be "hackers", but we are "hackers" in the same sense as Steve Wozniak or Dean Kamen are. We're not here to break into your ex's cell phone/computer/automobile, etc.. We're not the people who attack and deface web sites and steal people's credit cards or identities. In fact, many of us work in the very industries which protect against such people.
 
 #### How To Get Involved
 
 If you are in the Las Vegas valley area and are interested in the hackerspace idea, hop on our [Discord server](https://synshop.org/discord), or show up to a SYN Shop event. The best thing to do, of course, is become a full-fledged member!
 
-SYN Shop is a 501(c)(3) non-profit, which means that aside from membership dues, we survive entirely off of Donations from our community... which are tax deductible in most cases! If you would like to contribue, please visit our [donations page](/donate).
+SYN Shop is a 501(c)(3) non-profit, which means that aside from membership dues, we survive entirely off of Donations from our community... which are tax deductible in most cases! If you would like to contribute, please visit our [donations page](/donate).
 
 #### The Name
 
-What does the name "SYN Shop" mean, and why do we call ourselves by that name? When computers need to talk to one another over the network, SYN is the first packet sent out during the TCP three-way handshake. Since Hacker Spaces are about communication, we felt this was a good way of symbolizing what we do. You can also say that Syn, could stand for "Synergy". Synergy is defined as two or more things functioning together to produce a result not independently obtainable, which also fits well with the Hacker Space ideals. And lastly since we live in Las Vegas, SYN is a fun play on words and the city's often heard nick name "Sin City."
+What does the name "SYN Shop" mean, and why do we call ourselves by that name? When computers need to talk to one another over the network, SYN is the first packet sent out during the TCP three-way handshake. Since Hacker Spaces are about communication, we felt this was a good way of symbolizing what we do. You can also say that Syn, could stand for "Synergy". Synergy is defined as two or more things functioning together to produce a result not independently obtainable, which also fits well with the Hacker Space ideals. And lastly since we live in Las Vegas, SYN is a fun play on words with the city's often heard nickname "Sin City."
 
 #### Location
 We are located at:

--- a/_pages/donate.md
+++ b/_pages/donate.md
@@ -10,7 +10,7 @@ header:
 
 ## Donations
 
-We gladly accept donations, via our secure processing partner, Stripe. As a 501(c)(3) Non-Profit, your donations may be tax deductible. For any tax purposes, our EIN is 45-4657308. _(Please contact a staff member if you require additional verification paperwork for filing.)_
+We gladly accept donations, via our secure processing partner, Stripe. As a 501(c)(3) Non-Profit, your donations may be tax deductible. For any tax purposes, our EIN is 45-4657308. *(Please contact a staff member if you require additional verification paperwork for filing.)*
 
 <script async
   src="https://js.stripe.com/v3/buy-button.js">

--- a/_pages/membership.md
+++ b/_pages/membership.md
@@ -32,26 +32,26 @@ header:
 #### Regular Memberships
 Membership to SYN Shop is $50 per month. This gives you access to all of the collaboration areas, the classroom, the electronics lab and the shop WiFi during normal operating hours. You will also have voting rights on all regular shop matters.
 
-You must complete a very quick and to-the-point Tool Certification (TC) before you can operate the bigger / more expensive equipment on your own. Our goal isn't to be the mean and grumpy shop teacher, but we want to make sure that you aren't going to damage the tool or hurt yourself. We have designed TCs to give you a reference on how to operate the tool safely and properly.
+Some equipment, however, does require Tool Certification. *([Full details on this process are further below](#TCHeader))*
 
-<mark><b>Members must also follow our first rule, "Don't be a jerk"</b></mark> as well the others we have [published here](/assets/pdf/SYN_Shop_Rules_v3_2020-08-12.pdf).  Furthermore, the shop [has bylaws](/assets/pdf/SYN_Shop_Bylaws_-_2020-02-01.pdf) which govern how we operate.
+<mark><b>Members must also follow our first rule, "Don't be a jerk"</b></mark> as well the others we have [published here](/assets/pdf/SYN_Shop_Rules_v3_2020-08-12.pdf).  Furthermore, the shop [has bylaws](/assets/pdf/SYN_Shop_Bylaws_-_2020-02-01.pdf) which govern how we operate as an organization.
 
 #### Vetted Memberships
-Once you have be a member of SYN Shop for a while and feel like you are really contributing to the space, you can apply for Vetted Membership status. Vetted Membership status gives you access to the shop 24/7 in addition to the benefits of being a Regular Member.
+Once you have been a member of SYN Shop for a while, and feel like you are really contributing to the space, you can apply for Vetted Membership status. Vetted Membership status gives you access to the shop 24/7 in addition to the benefits of being a Regular Member.
 
-To become a vetted member, your application will be reviewed by the board of directors for approval. The board would love to give everyone vetted membership immediately, but we want to make sure you are going to help protect the reputation of SYN Shop and be super passionate about building an awesome community of Makers.
+To become a vetted member, you will need to submit an application that has been signed by other Vetted Members to sponsor you. Your application will then be reviewed by the board of directors for approval at the next Monthly Board Meeting. The board would love to give everyone vetted membership immediately, but we want to make sure you are going to help protect the reputation of SYN Shop, and actively participate in building an awesome community of Makers with passion.
 
 #### Drop-in Memberships
 We don't have drop-in memberships at this time, but we are always willing to give a tour of the space during normal operating hours. Classes are always open to the public.
 
 #### Collaboration with Non SYN Shop Members
-Hey, we know that from time to time you will be working on a project that involves non SYN Shop members. When doing so, you are welcome to host up to two guests. We do ask that they consider giving a general donation to SYN Shop (or become members) if they are going to be using the space a considerable amount.
+Hey, we know that from time to time you will be working on a project that involves non SYN Shop members. When doing so, you are welcome to host up to two guests. We do kindly ask that they consider giving a general donation to SYN Shop (or become members) if they are going to be using the space a considerable amount during this time.
 
 #### Liability Wavier
-Please print, sign and return [this waiver to SYN Shop](/assets/pdf/SYN_Shop_Liability_Waiver_Members.pdf).  You can submit it by either emailing a scanned copy to <a href="mailto:info@synshop.org">info@synshop.org</a> or bring it down to the shop and we'll file it away for you.
+Please print, sign, and return [this waiver to SYN Shop](/assets/pdf/SYN_Shop_Liability_Waiver_Members.pdf).  You can submit it by either emailing a scanned copy to <a href="mailto:info@synshop.org">info@synshop.org</a> or bring it down to the shop and we'll file it away for you.
 
-#### Tool Certifications
-You must complete a very quick and to-the-point Tool Certification (TC) before you can operate the bigger / more expensive equipment on your own. Our goal isn't to be the mean and grumpy shop teacher, but we want to make sure that you aren't going to damage the tool or hurt yourself. We have designed TCs to give you a reference on how to operate the tool safely and properly.
+#### <a name="TCHeader"></a>Tool Certifications
+You must complete a very quick and to-the-point Tool Certification (TC) before you can operate the bigger, more expensive equipment on your own. Our goal isn't to be the mean and grumpy shop teacher, but we want to make sure that you aren't going to damage the tool or hurt yourself. We have designed TCs to give you a reference on how to operate the tool safely and properly.
 
 #### Hours of Operation
 Please see the [hours page](/hours) for more details.

--- a/_pages/membership.md
+++ b/_pages/membership.md
@@ -57,4 +57,4 @@ You must complete a very quick and to-the-point Tool Certification (TC) before y
 Please see the [hours page](/hours) for more details.
 
 #### Lockers
-We have lockers available on a first come / first serve basis and cost an additional $10/mo.
+We have lockers available on a first come, first serve basis at an additional $10/mo.

--- a/index.md
+++ b/index.md
@@ -29,8 +29,8 @@ SYN Shop is a hackerspace serving the Las Vegas Valley in Nevada. It is a space 
 
 We are hackers, makers, artists, innovators, inventors, people of knowledge, and people who want to learn. We are people who take things apart to see how they work. We design the new because it has not been done before, and we reinvent what has already been done for the challenge of doing it ourselves. We're here to discover the unknown, to teach others, and to put our mark on the world by helping others. We're here to form a community of people who come together to share resources and knowledge to build and make things.
 
-### What We Are Not
+### Who We Are ***Not***
 
-We may be hackers, but we are hackers in the same sense as Steve Wozniak or Dean Kamen are. We're not here to break into your ex's cell phone/computer/automobile, etc.. We're not the people who attack and deface web sites, steal people's credit card information, or identities. In fact, many of us work in the industries which protect against such people.
+We may be "hackers", but we are "hackers" in the same sense as Steve Wozniak or Dean Kamen are. We're not here to break into your ex's cell phone/computer/automobile, etc.. We're not the people who attack and deface web sites and steal people's credit cards or identities. In fact, many of us work in the very industries which protect against such people.
 
 {% include feature_row %}


### PR DESCRIPTION
Various text and copy cleanups. Mostly grammar and punctuation, 2 or 3 typos, and removed some redundant text that appears twice on one page with a header-ref link between the two instead to reduce content drift.